### PR TITLE
fixes for compile time errors with 2.059

### DIFF
--- a/deimos/openssl/pkcs12.d
+++ b/deimos/openssl/pkcs12.d
@@ -62,6 +62,7 @@ import deimos.openssl._d_util;
 
 public import deimos.openssl.bio;
 public import deimos.openssl.x509;
+public import deimos.openssl.pkcs7;
 
 extern (C):
 nothrow:

--- a/deimos/openssl/ts.d
+++ b/deimos/openssl/ts.d
@@ -74,6 +74,7 @@ public import deimos.openssl.bio;
 public import deimos.openssl.stack;
 public import deimos.openssl.asn1;
 public import deimos.openssl.safestack;
+public import deimos.openssl.pkcs7;
 
 version(OPENSSL_NO_RSA) {} else {
 public import deimos.openssl.rsa;


### PR DESCRIPTION
i wanted to compile this program (similar to sha1sum) and got some errors. the added imports fixed it.
perhaps the imports should not be public?

regards

import deimos.openssl.evp;
import std.stdio;

int main(string[] args) {
  // prepare input
  if (args.length != 2) {
    writeln("Usage ", args[0], " filename");
    return 1;
  }
  auto fileName = args[1];
  auto inputFile = File(fileName, "rb");

  // work with openssl
  OpenSSL_add_all_digests();
  auto digest = EVP_get_digestbyname("sha1");
  EVP_MD_CTX ctx;
  EVP_MD_CTX_init(&ctx);
  scope (exit) { EVP_MD_CTX_cleanup(&ctx); }

  EVP_DigestInit(&ctx, digest);
  foreach (buffer; inputFile.byChunk(4096)) {
    EVP_DigestUpdate(&ctx, buffer.ptr, buffer.length);
  }

  // get result from openssl
  ubyte value[EVP_MAX_MD_SIZE];
  uint len;
  EVP_DigestFinal(&ctx, value.ptr, &len);

  // output
  foreach (v; value[0..len]) {
    writef("%x", v);
  }
  writeln(" ", fileName);
  return 0;
}
