### PR TITLE
typo in ec.d

### DIFF
--- a/deimos/openssl/ec.d
+++ b/deimos/openssl/ec.d
@@ -952,7 +952,7 @@ auto ECParameters_dup()(EC_KEY* x) {return ASN1_dup_of!EC_KEY(&i2d_ECParameters,
 //# endif
 //#endif
 
-auto EVP_PKEY_CTX_set_ec_paramgen_curve_nid()(EVP_PKEX_CTX* ctx, int nid) {
+auto EVP_PKEY_CTX_set_ec_paramgen_curve_nid()(EVP_PKEY_CTX* ctx, int nid) {
 	return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, EVP_PKEY_OP_PARAMGEN,
 				EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, null);
 }


### PR DESCRIPTION
please pay attention to this simple one-letter patch

without patch usage of this function causes:

../.dub/packages/openssl-1.1.3_1.0.1g/deimos/openssl/ec.d(955): Error: undefined identifier EVP_PKEX_CTX, did you mean alias EVP_PKEY_CTX?