### PR TITLE
crypto.d: Fix template OPENSSL_malloc

### DIFF
--- a/deimos/openssl/crypto.d
+++ b/deimos/openssl/crypto.d
@@ -119,6 +119,7 @@ module deimos.openssl.crypto;
 import deimos.openssl._d_util;
 
 import core.stdc.stdlib;
+import std.string : toStringz;
 
 public import deimos.openssl.e_os2;
 
@@ -368,7 +369,7 @@ int MemCheck_off()() { return CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE); }
 alias CRYPTO_is_mem_check_on is_MemCheck_on;
 
 auto OPENSSL_malloc(string file = __FILE__, size_t line = __LINE__)(int num) {
-	return CRYPTO_malloc(num,file,line);
+	return CRYPTO_malloc(num,file.toStringz,line);
 }
 auto OPENSSL_strdup(string file = __FILE__, size_t line = __LINE__)(const(char)* str) {
 	return CRYPTO_strdup(str,file,line);

--- a/deimos/openssl/crypto.d
+++ b/deimos/openssl/crypto.d
@@ -119,7 +119,6 @@ module deimos.openssl.crypto;
 import deimos.openssl._d_util;
 
 import core.stdc.stdlib;
-import std.string : toStringz;
 
 public import deimos.openssl.e_os2;
 
@@ -237,19 +236,19 @@ version (OPENSSL_NO_LOCKING) {
 	void CRYPTO_add()(int* addr, int amount, int type) { *addr += amount; }
 } else {
 	void CRYPTO_w_lock(string file = __FILE__, size_t line = __LINE__)(int type) {
-		CRYPTO_lock(CRYPTO_LOCK|CRYPTO_WRITE,type,file,line);
+		CRYPTO_lock(CRYPTO_LOCK|CRYPTO_WRITE,type,file.ptr,line);
 	}
 	void CRYPTO_w_unlock(string file = __FILE__, size_t line = __LINE__)(int type) {
-		CRYPTO_lock(CRYPTO_UNLOCK|CRYPTO_WRITE,type,file,line);
+		CRYPTO_lock(CRYPTO_UNLOCK|CRYPTO_WRITE,type,file.ptr,line);
 	}
 	void CRYPTO_r_lock(string file = __FILE__, size_t line = __LINE__)(int type) {
-		CRYPTO_lock(CRYPTO_LOCK|CRYPTO_READ,type,file,line);
+		CRYPTO_lock(CRYPTO_LOCK|CRYPTO_READ,type,file.ptr,line);
 	}
 	void CRYPTO_r_unlock(string file = __FILE__, size_t line = __LINE__)(int type) {
-		CRYPTO_lock(CRYPTO_UNLOCK|CRYPTO_READ,type,file,line);
+		CRYPTO_lock(CRYPTO_UNLOCK|CRYPTO_READ,type,file.ptr,line);
 	}
 	void CRYPTO_add(string file = __FILE__, size_t line = __LINE__)(int* addr, int amount, int type) {
-		CRYPTO_add_lock(addr,amount,type,file,line);
+		CRYPTO_add_lock(addr,amount,type,file.ptr,line);
 	}
 }
 
@@ -369,25 +368,25 @@ int MemCheck_off()() { return CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE); }
 alias CRYPTO_is_mem_check_on is_MemCheck_on;
 
 auto OPENSSL_malloc(string file = __FILE__, size_t line = __LINE__)(int num) {
-	return CRYPTO_malloc(num,file.toStringz,line);
+	return CRYPTO_malloc(num,file.ptr,line);
 }
 auto OPENSSL_strdup(string file = __FILE__, size_t line = __LINE__)(const(char)* str) {
-	return CRYPTO_strdup(str,file,line);
+	return CRYPTO_strdup(str,file.ptr,line);
 }
 auto OPENSSL_realloc(string file = __FILE__, size_t line = __LINE__)(void* addr, int num) {
-	return CRYPTO_realloc(addr,num,file,line);
+	return CRYPTO_realloc(addr,num,file.ptr,line);
 }
 auto OPENSSL_realloc_clean(string file = __FILE__, size_t line = __LINE__)(void* addr,int old_num,int num) {
-	CRYPTO_realloc_clean(addr,old_num,num,file,line);
+	CRYPTO_realloc_clean(addr,old_num,num,file.ptr,line);
 }
 auto OPENSSL_remalloc(string file = __FILE__, size_t line = __LINE__)(void** addr, int num) {
-	return CRYPTO_remalloc(cast(char**)addr,num,file,line);
+	return CRYPTO_remalloc(cast(char**)addr,num,file.ptr,line);
 }
 alias CRYPTO_free OPENSSL_freeFunc;
 alias CRYPTO_free OPENSSL_free;
 
 auto OPENSSL_malloc_locked(string file = __FILE__, size_t line = __LINE__)(int num) {
-	return CRYPTO_malloc_locked(num, file, line);
+	return CRYPTO_malloc_locked(num, file.ptr, line);
 }
 alias CRYPTO_free_locked OPENSSL_free_locked;
 
@@ -514,7 +513,7 @@ void CRYPTO_set_mem_debug_options(c_long bits);
 c_long CRYPTO_get_mem_debug_options();
 
 auto CRYPTO_push_info(string file = __FILE__, size_t line = __LINE__)(const(char)* info) {
-	return CRYPTO_push_info_(info, file, line);
+	return CRYPTO_push_info_(info, file.ptr, line);
 }
 int CRYPTO_push_info_(const(char)* info, const(char)* file, int line);
 int CRYPTO_pop_info();
@@ -554,7 +553,7 @@ void CRYPTO_mem_leaks_cb(CRYPTO_MEM_LEAK_CB* cb);
 /* die if we have to */
 void OpenSSLDie(const(char)* file,int line,const(char)* assertion);
 void OPENSSL_assert(string file = __FILE__, size_t line = __LINE__)(int e) {
-	if (!e) OpenSSLDie(file, line, "assertion failed"); // No good way to translate.
+	if (!e) OpenSSLDie(file.ptr, line, "assertion failed"); // No good way to translate.
 }
 
 c_ulong* OPENSSL_ia32cap_loc();


### PR DESCRIPTION
calling e.g. OPENSSL_malloc(16);
doesn't compile (actually DMD64 D Compiler v2.077.1, though it doesn't matter here):

../../.dub/packages/openssl-1.1.6_1.0.1g/openssl/deimos/openssl/crypto.d(371,22): Error: function deimos.openssl.crypto.CRYPTO_malloc (int num, const(char)* file, int line) is not callable using argument types (int, string, ulong)
source/acos5_64.d(2423,15): Error: template instance deimos.openssl.crypto.OPENSSL_malloc!("source/acos5_64.d", 2423LU) error instantiating

The proposed PR solves for this one case, though there are more templates using template parameters (string file = __FILE__, size_t line = __LINE__) that woun't compile.
If this PR is accepted, I will follow-up with another PR referring to those.

In another context (one of my bindings) I faced a peculiarity about Special Keywords __FUNCTION__, __PRETTY_FUNCTION__ opposed to __MODULE__ already:
void  sc_do_log(sc_context* ctx, int level, const(char)* file, int line, const(char)* func, const(char)* format, ...); // an "exact" match to the C header
isn't callable by: sc_do_log(ctx, SC_LOG_DEBUG_NORMAL, __MODULE__, line, __FUNCTION__,           "some msg");
but callable   by: sc_do_log(ctx, SC_LOG_DEBUG_NORMAL, __MODULE__, line, __FUNCTION__.toStringz, "some msg");
that is, __MODULE__ is accepted as string literal, but __FUNCTION__, __PRETTY_FUNCTION__, now __FILE__ are not.
Perhaps it is possible to change DMD in order to ease passing preferably all D's "string" Special Keywords as literals to C-like const(char)* parameters, or at least be shure that a '\0' is immediatelly following their storage location if there is any, thus avoiding allocation of toStringz and just pass e.g. __FUNCTION__.ptr. I tried passing __FUNCTION__.ptr and it worked, but being not shure I skipped that.
