### PR TITLE
Update to openssl 1.1.0h support

### DIFF
--- a/deimos/openssl/hmac.d
+++ b/deimos/openssl/hmac.d
@@ -84,9 +84,9 @@ alias hmac_ctx_st HMAC_CTX;
 
 auto HMAC_size()(HMAC_CTX* e) { return EVP_MD_size(e.md); }
 
-
-void HMAC_CTX_init(HMAC_CTX* ctx);
-void HMAC_CTX_cleanup(HMAC_CTX* ctx);
+HMAC_CTX * HMAC_CTX_new();
+void HMAC_CTX_free(HMAC_CTX *ctx);
+void HMAC_CTX_reset(HMAC_CTX * ctx);
 
 alias HMAC_CTX_cleanup HMAC_cleanup; /* deprecated */
 


### PR DESCRIPTION
Defined these methods which are defined in openssl 1.1.0h:
HMAC_CTX * HMAC_CTX_new();
void HMAC_CTX_free(HMAC_CTX *ctx);
void HMAC_CTX_reset(HMAC_CTX * ctx);

Removed deprecated methods which result in an unresolved symbol:
void HMAC_CTX_init(HMAC_CTX* ctx);
void HMAC_CTX_cleanup(HMAC_CTX* ctx);