### PR TITLE
Add and enhance missing declarations and defines

### DIFF
--- a/deimos/openssl/asn1.d
+++ b/deimos/openssl/asn1.d
@@ -879,7 +879,8 @@ int ASN1_UTCTIME_cmp_time_t(const(ASN1_UTCTIME)* s, time_t t);
 version (none) {
 time_t ASN1_UTCTIME_get(const(ASN1_UTCTIME)* s);
 }
-
+int ASN1_TIME_diff(int *pday, int *psec,
+                   const ASN1_TIME *from, const ASN1_TIME *to);
 int ASN1_GENERALIZEDTIME_check(ASN1_GENERALIZEDTIME* a);
 ASN1_GENERALIZEDTIME* ASN1_GENERALIZEDTIME_set(ASN1_GENERALIZEDTIME* s,time_t t);
 ASN1_GENERALIZEDTIME* ASN1_GENERALIZEDTIME_adj(ASN1_GENERALIZEDTIME* s,

--- a/deimos/openssl/evp.d
+++ b/deimos/openssl/evp.d
@@ -551,8 +551,9 @@ auto EVP_delete_digest_alias()(const(char)* alias_) {
 
 void	EVP_MD_CTX_init(EVP_MD_CTX* ctx);
 int	EVP_MD_CTX_cleanup(EVP_MD_CTX* ctx);
-EVP_MD_CTX* EVP_MD_CTX_create();
 void	EVP_MD_CTX_destroy(EVP_MD_CTX* ctx);
+EVP_MD_CTX* EVP_MD_CTX_new();
+alias EVP_MD_CTX_new EVP_MD_CTX_create;
 int     EVP_MD_CTX_copy_ex(EVP_MD_CTX* out_,const(EVP_MD_CTX)* in_);
 void	EVP_MD_CTX_set_flags(EVP_MD_CTX* ctx, int flags);
 void	EVP_MD_CTX_clear_flags(EVP_MD_CTX* ctx, int flags);

--- a/deimos/openssl/evp.d
+++ b/deimos/openssl/evp.d
@@ -551,9 +551,10 @@ auto EVP_delete_digest_alias()(const(char)* alias_) {
 
 void	EVP_MD_CTX_init(EVP_MD_CTX* ctx);
 int	EVP_MD_CTX_cleanup(EVP_MD_CTX* ctx);
-void	EVP_MD_CTX_destroy(EVP_MD_CTX* ctx);
 EVP_MD_CTX* EVP_MD_CTX_new();
 alias EVP_MD_CTX_new EVP_MD_CTX_create;
+void	EVP_MD_CTX_free(EVP_MD_CTX* ctx);
+alias EVP_MD_CTX_free EVP_MD_CTX_destroy;
 int     EVP_MD_CTX_copy_ex(EVP_MD_CTX* out_,const(EVP_MD_CTX)* in_);
 void	EVP_MD_CTX_set_flags(EVP_MD_CTX* ctx, int flags);
 void	EVP_MD_CTX_clear_flags(EVP_MD_CTX* ctx, int flags);

--- a/deimos/openssl/x509.d
+++ b/deimos/openssl/x509.d
@@ -617,8 +617,8 @@ auto X509_get_version()(x509_st* x) { return ASN1_INTEGER_get(x.cert_info.versio
 auto X509_get_notBefore()(x509_st* x) { return (x.cert_info.validity.notBefore); }
 auto X509_get_notAfter()(x509_st* x) { return (x.cert_info.validity.notAfter); }
 alias X509_get_pubkey X509_extract_key;
-auto X509_REQ_get_version()(x509_st* x) { return ASN1_INTEGER_get(x.req_info.version_); }
-auto X509_REQ_get_subject_name()(x509_st* x) { return (x.req_info.subject); }
+auto X509_REQ_get_version()(X509_req_st* x) { return ASN1_INTEGER_get(x.req_info.version_); }
+auto X509_REQ_get_subject_name()(X509_req_st* x) { return (x.req_info.subject); }
 alias X509_REQ_get_pubkey X509_REQ_extract_key;
 alias X509_NAME_cmp X509_name_cmp;
 auto X509_get_signature_type()(x509_st* x) { return EVP_PKEY_type(OBJ_obj2nid(x.sig_alg.algorithm)); }


### PR DESCRIPTION
The declaration for EVP_MD_CTX_new() is missing. EVP_MD_CTX_create() is
just an CPrepro alias for EVP_MD_CTX_new().