### PR TITLE
bio: Fix BIO ctrl callback signature (long -> c_long)

### DIFF
--- a/source/deimos/openssl/bio.d
+++ b/source/deimos/openssl/bio.d
@@ -779,7 +779,7 @@ int BIO_meth_set_puts(BIO_METHOD *biom,
 int function(BIO_METHOD *biom) BIO_meth_get_gets(BIO *, char *, int);
 int BIO_meth_set_gets(BIO_METHOD *biom,
                       int function(BIO *, char *, int) gets);
-c_long function(BIO_METHOD *biom) BIO_meth_get_ctrl(BIO *, int, c_long, void *);
+c_long function(BIO *, int, c_long, void *) BIO_meth_get_ctrl(BIO_METHOD *biom);
 int BIO_meth_set_ctrl(BIO_METHOD *biom,
                       c_long function(BIO *, int, c_long, void *) ctrl);
 int function(BIO_METHOD *bion) BIO_meth_get_create(BIO *);


### PR DESCRIPTION
I was in the process of updating Vibe.d (https://github.com/vibe-d/vibe.d/pull/2658) and got an LDC error on Windows x86:
```
vibe-d:tls 0.9.5-beta.1+commit.7.g47e24054: building configuration "vibe-d-tls-test-openssl-mscoff"...
tls\vibe\stream\openssl.d(163,7): Error: Function type does not match previously declared function with the same mangled name: `BIO_meth_set_ctrl`
tls\vibe\stream\openssl.d(163,7):        Previous IR type: i32 (%deimos.openssl.bio.bio_method_st*, i64 (%deimos.openssl.bio.bio_st*, i32, i64, i8*)*)
tls\vibe\stream\openssl.d(163,7):        New IR type:      i32 (%deimos.openssl.bio.bio_method_st*, i32 (%deimos.openssl.bio.bio_st*, i32, i32, i8*)*)
```

Turns out Vibe.d was in the right here, and the bindings here are wrong, see [the man page](https://www.openssl.org/docs/man1.1.1/man3/BIO_meth_set_ctrl.html)

While looking into it, I also notices that `BIO_meth_get_ctrl` seemed wrong here. The man page says:
```
 long (*BIO_meth_get_ctrl(const BIO_METHOD *biom))(BIO *, int, long, void *);
 int BIO_meth_set_ctrl(BIO_METHOD *biom,
                       long (*ctrl)(BIO *, int, long, void *));
```

So I'd expect it to be translated to:
```D
c_long function(BIO *, int, c_long, void *) BIO_meth_get_ctrl(BIO_METHOD *biom);
```
and not to:
```D
c_long function(BIO_METHOD *biom) BIO_meth_get_ctrl(BIO *, int, c_long, void *);
```

Which is how `BIO_meth_get_callback_ctrl` got translated. Added a commit to fix that as well.