### PR TITLE
CI: Use the correct key when looking up OpenSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ github.workspace }}/openssl/
-        key: ${{ matrix.os }}-${{ matrix.openssl.version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.openssl.version }}
 
     - name: 'Make sure OpenSSL was loaded from cache'
       if: steps.lookup-openssl.outputs.cache-hit != 'true'


### PR DESCRIPTION
```
While working on the CI, I ended up changing the scheme used for the key,
but as the old scheme had been looked up successfully in my fork,
it didn't break until it landed on master.
```

See L38 for the correct scheme.