### PR TITLE
rsa: `rsa_method_st` and `rsa_st` are opaque since v1.1.0

### DIFF
--- a/source/deimos/openssl/evp.d
+++ b/source/deimos/openssl/evp.d
@@ -137,7 +137,7 @@ struct evp_pkey_st
 	union pkey_ {
 		char* ptr;
 version(OPENSSL_NO_RSA) {} else {
-		rsa_st* rsa;	/* RSA */
+		RSA* rsa;	/* RSA */
 }
 version(OPENSSL_NO_DSA) {} else {
 		dsa_st* dsa;	/* DSA */
@@ -901,9 +901,9 @@ int 		EVP_PKEY_assign(EVP_PKEY* pkey,int type,void* key);
 void* 		EVP_PKEY_get0(EVP_PKEY* pkey);
 
 version(OPENSSL_NO_RSA) {} else {
-import deimos.openssl.rsa; /*struct rsa_st;*/
-int EVP_PKEY_set1_RSA(EVP_PKEY* pkey,rsa_st* key);
-rsa_st* EVP_PKEY_get1_RSA(EVP_PKEY* pkey);
+import deimos.openssl.rsa;
+int EVP_PKEY_set1_RSA(EVP_PKEY* pkey, RSA* key);
+RSA* EVP_PKEY_get1_RSA(EVP_PKEY* pkey);
 }
 version(OPENSSL_NO_DSA) {} else {
 import deimos.openssl.dsa; /*struct dsa_st;*/

--- a/source/deimos/openssl/rsa.d
+++ b/source/deimos/openssl/rsa.d
@@ -34,7 +34,6 @@ extern (C):
 nothrow:
 
 /* Declared already in types.h */
-/* typedef rsa_st RSA; */
 /* typedef rsa_meth_st RSA_METHOD; */
 
 struct rsa_meth_st
@@ -81,8 +80,25 @@ struct rsa_meth_st
 	ExternC!(int function(RSA* rsa, int bits, BIGNUM* e, BN_GENCB* cb)) rsa_keygen;
 	};
 
+static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+{
+	// https://github.com/openssl/openssl/commit/9862e9aa98ee1e38fbcef8d1dd5db0e750eb5e8d
+	int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+	int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q);
+	int RSA_set0_crt_params(RSA *r,BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp);
+	void RSA_get0_key(const RSA *r, BIGNUM **n, BIGNUM **e, BIGNUM **d);
+	void RSA_get0_factors(const RSA *r, BIGNUM **p, BIGNUM **q);
+	void RSA_get0_crt_params(const RSA *r,
+							 BIGNUM **dmp1, BIGNUM **dmq1, BIGNUM **iqmp);
+	void RSA_clear_flags(RSA *r, int flags);
+	int RSA_test_flags(const RSA *r, int flags);
+	void RSA_set_flags(RSA *r, int flags);
+	ENGINE *RSA_get0_engine(RSA *r);
+}
+else
+{
 struct rsa_st
-	{
+{
 	/* The first parameter is used to pickup errors where
 	 * this is passed instead of aEVP_PKEY, it is set to 0 */
 	int pad;
@@ -113,7 +129,8 @@ struct rsa_st
 	char* bignum_data;
 	BN_BLINDING* blinding;
 	BN_BLINDING* mt_blinding;
-	};
+}
+}
 
 // #ifndef OPENSSL_RSA_MAX_MODULUS_BITS
 enum OPENSSL_RSA_MAX_MODULUS_BITS = 16384;

--- a/source/deimos/openssl/rsa.d
+++ b/source/deimos/openssl/rsa.d
@@ -1,61 +1,13 @@
-/* crypto/rsa/rsa.h */
-/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
- * All rights reserved.
+/**
+ * Port of `openssl.rsa.h`
  *
- * This package is an SSL implementation written
- * by Eric Young (eay@cryptsoft.com).
- * The implementation was written so as to conform with Netscapes SSL.
+ * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
  *
- * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
- * apply to all code found in this distribution, be it the RC4, RSA,
- * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
- * included with this distribution is covered by the same copyright terms
- * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- *
- * Copyright remains Eric Young's, and as such any Copyright notices in
- * the code are not to be removed.
- * If this package is used in a product, Eric Young should be given attribution
- * as the author of the parts of the library used.
- * This can be in the form of a textual message at program startup or
- * in documentation (online or textual) provided with the package.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the copyright
- *   notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *   notice, this list of conditions and the following disclaimer in the
- *   documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *   must display the following acknowledgement:
- *   "This product includes cryptographic software written by
- *    Eric Young (eay@cryptsoft.com)"
- *   The word 'cryptographic' can be left out if the rouines from the library
- *   being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from
- *   the apps directory (application code) you must include an acknowledgement:
- *   "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
- *
- * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * The licence and distribution terms for any publically available version or
- * derivative of this code cannot be changed.  i.e. this code cannot simply be
- * copied and put under another distribution licence
- * [including the GNU Public Licence.]
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
  */
-
 module deimos.openssl.rsa;
 
 import deimos.openssl._d_util;

--- a/source/deimos/openssl/types.d
+++ b/source/deimos/openssl/types.d
@@ -115,7 +115,7 @@ alias dsa_method DSA_METHOD;
 import deimos.openssl.rsa;
 private struct rsa_st;
 alias rsa_st RSA;
-/*struct rsa_meth_st;*/
+private struct rsa_meth_st;
 alias rsa_meth_st RSA_METHOD;
 
 import deimos.openssl.rand;

--- a/source/deimos/openssl/types.d
+++ b/source/deimos/openssl/types.d
@@ -113,7 +113,7 @@ alias dsa_st DSA;
 alias dsa_method DSA_METHOD;
 
 import deimos.openssl.rsa;
-/*struct rsa_st;*/
+private struct rsa_st;
 alias rsa_st RSA;
 /*struct rsa_meth_st;*/
 alias rsa_meth_st RSA_METHOD;


### PR DESCRIPTION
The RSA header is hugely different from what is checked in. Trying to fix this while retaining compatibility with all supported versions is challenging.