### PR TITLE
Change *_get_ex_new_index functions to macros

### DIFF
--- a/source/deimos/openssl/bio.d
+++ b/source/deimos/openssl/bio.d
@@ -621,8 +621,19 @@ auto BIO_dgram_set_peer()(BIO* b,void* peer) { return cast(int) BIO_ctrl(b, BIO_
 /* void BIO_set_ex_free_func(BIO* bio,int idx,ExternC!(void function()) cb); */
 int BIO_set_ex_data(BIO* bio,int idx,void* data);
 void* BIO_get_ex_data(BIO* bio,int idx);
-int BIO_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int BIO_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto BIO_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_BIO, l, p, newf, dupf, freef);
+	}
+}
 c_ulong BIO_number_read(BIO* bio);
 c_ulong BIO_number_written(BIO* bio);
 

--- a/source/deimos/openssl/crypto.d
+++ b/source/deimos/openssl/crypto.d
@@ -156,20 +156,6 @@ enum SSLEAY_BUILT_ON = 3;
 enum SSLEAY_PLATFORM = 4;
 enum SSLEAY_DIR = 5;
 
-/* Already declared in types.h */
-/+#if 0
-alias crypto_ex_data_st CRYPTO_EX_DATA;
-/* Called when a new object is created */
-typedef int CRYPTO_EX_new(void* parent, void* ptr, CRYPTO_EX_DATA* ad,
-					int idx, c_long argl, void* argp);
-/* Called when an object is free()ed */
-typedef void CRYPTO_EX_free(void* parent, void* ptr, CRYPTO_EX_DATA* ad,
-					int idx, c_long argl, void* argp);
-/* Called when we need to dup an object */
-typedef int CRYPTO_EX_dup(CRYPTO_EX_DATA* to, CRYPTO_EX_DATA* from, void* from_d,
-					int idx, c_long argl, void* argp);
-#endif+/
-
 /* A generic structure to pass assorted data in a expandable way */
 struct openssl_item_st {
 	int code;
@@ -412,6 +398,11 @@ int CRYPTO_ex_data_new_class();
 int CRYPTO_get_ex_new_index(int class_index, c_long argl, void* argp,
 		CRYPTO_EX_new* new_func, CRYPTO_EX_dup* dup_func,
 		CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+{
+	/* No longer use an index. */
+	int CRYPTO_free_ex_index(int class_index, int idx);
+}
 /* Initialise/duplicate/free CRYPTO_EX_DATA variables corresponding to a given
  * class (invokes whatever per-class callbacks are applicable) */
 int CRYPTO_new_ex_data(int class_index, void* obj, CRYPTO_EX_DATA* ad);
@@ -599,6 +590,7 @@ enum CRYPTO_F_CRYPTO_SET_EX_DATA = 102;
 enum CRYPTO_F_DEF_ADD_INDEX = 104;
 enum CRYPTO_F_DEF_GET_CLASS = 105;
 enum CRYPTO_F_FIPS_MODE_SET = 109;
+enum CRYPTO_F_GET_AND_LOCK  = 113;
 enum CRYPTO_F_INT_DUP_EX_DATA = 106;
 enum CRYPTO_F_INT_FREE_EX_DATA = 107;
 enum CRYPTO_F_INT_NEW_EX_DATA = 108;

--- a/source/deimos/openssl/dh.d
+++ b/source/deimos/openssl/dh.d
@@ -195,8 +195,20 @@ DH* 	DH_new();
 void	DH_free(DH* dh);
 int	DH_up_ref(DH* dh);
 int	DH_size(const(DH)* dh);
-int DH_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	     CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int DH_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		 CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto DH_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup dupf, CRYPTO_EX_free freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DH, l, p, newf, dupf, freef);
+	}
+}
 int DH_set_ex_data(DH* d, int idx, void* arg);
 void* DH_get_ex_data(DH* d, int idx);
 

--- a/source/deimos/openssl/dsa.d
+++ b/source/deimos/openssl/dsa.d
@@ -218,8 +218,19 @@ int	DSA_sign(int type,const(ubyte)* dgst,int dlen,
 		ubyte* sig, uint* siglen, DSA* dsa);
 int	DSA_verify(int type,const(ubyte)* dgst,int dgst_len,
 		const(ubyte)* sigbuf, int siglen, DSA* dsa);
-int DSA_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	     CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int DSA_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto DSA_get_ex_new_index(c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DSA, l, p, newf, dupf, freef);
+	}
+}
 int DSA_set_ex_data(DSA* d, int idx, void* arg);
 void* DSA_get_ex_data(DSA* d, int idx);
 

--- a/source/deimos/openssl/ecdh.d
+++ b/source/deimos/openssl/ecdh.d
@@ -94,8 +94,19 @@ int 	  ECDH_set_method(EC_KEY*, const(ECDH_METHOD)*);
 int ECDH_compute_key(void* out_, size_t outlen, const(EC_POINT)* pub_key, EC_KEY* ecdh,
                      ExternC!(void* function(const(void)* in_, size_t inlen, void* out_, size_t* outlen)) KDF);
 
-int 	  ECDH_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new
-		*new_func, CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int ECDH_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto ECDH_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_ECDH, l, p, newf, dupf, freef);
+	}
+}
 int 	  ECDH_set_ex_data(EC_KEY* d, int idx, void* arg);
 void* ECDH_get_ex_data(EC_KEY* d, int idx);
 

--- a/source/deimos/openssl/ecdsa.d
+++ b/source/deimos/openssl/ecdsa.d
@@ -223,8 +223,19 @@ int 	  ECDSA_verify(int type, const(ubyte)* dgst, int dgstlen,
 		const(ubyte)* sig, int siglen, EC_KEY* eckey);
 
 /* the standard ex_data functions */
-int 	  ECDSA_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new
-		*new_func, CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int ECDSA_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto ECDSA_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_ECDSA, l, p, newf, dupf, freef);
+	}
+}
 int 	  ECDSA_set_ex_data(EC_KEY* d, int idx, void* arg);
 void* ECDSA_get_ex_data(EC_KEY* d, int idx);
 

--- a/source/deimos/openssl/engine.d
+++ b/source/deimos/openssl/engine.d
@@ -497,8 +497,19 @@ int ENGINE_set_pkey_asn1_meths(ENGINE* e, ENGINE_PKEY_ASN1_METHS_PTR f);
 int ENGINE_set_flags(ENGINE* e, int flags);
 int ENGINE_set_cmd_defns(ENGINE* e, const(ENGINE_CMD_DEFN)* defns);
 /* These functions allow control over any per-structure ENGINE data. */
-int ENGINE_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int ENGINE_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
 		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto ENGINE_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_ENGINE, l, p, newf, dupf, freef);
+	}
+}
 int ENGINE_set_ex_data(ENGINE* e, int idx, void* arg);
 void* ENGINE_get_ex_data(const(ENGINE)* e, int idx);
 

--- a/source/deimos/openssl/rsa.d
+++ b/source/deimos/openssl/rsa.d
@@ -539,8 +539,19 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, ubyte* EM,
 			const(ubyte)* mHash,
 			const(EVP_MD)* Hash, const(EVP_MD)* mgf1Hash, int sLen);
 
-int RSA_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int RSA_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto RSA_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_RSA, l, p, newf, dupf, freef);
+	}
+}
 int RSA_set_ex_data(RSA* r,int idx,void* arg);
 void* RSA_get_ex_data(const(RSA)* r, int idx);
 

--- a/source/deimos/openssl/ssl.d
+++ b/source/deimos/openssl/ssl.d
@@ -2179,18 +2179,42 @@ c_long SSL_get_verify_result(const(SSL)* ssl);
 
 int SSL_set_ex_data(SSL* ssl,int idx,void* data);
 void* SSL_get_ex_data(const(SSL)* ssl,int idx);
-int SSL_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int SSL_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+	int SSL_SESSION_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+	int SSL_CTX_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto SSL_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL, l, p, newf, dupf, freef);
+	}
+
+	auto SSL_SESSION_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_SESSION, l, p, newf, dupf, freef);
+	}
+
+	auto SSL_CTX_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX, l, p, newf, dupf, freef);
+	}
+}
 
 int SSL_SESSION_set_ex_data(SSL_SESSION* ss,int idx,void* data);
 void* SSL_SESSION_get_ex_data(const(SSL_SESSION)* ss,int idx);
-int SSL_SESSION_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
 
 int SSL_CTX_set_ex_data(SSL_CTX* ssl,int idx,void* data);
 void* SSL_CTX_get_ex_data(const(SSL_CTX)* ssl,int idx);
-int SSL_CTX_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
 
 int SSL_get_ex_data_X509_STORE_CTX_idx();
 

--- a/source/deimos/openssl/ui.d
+++ b/source/deimos/openssl/ui.d
@@ -227,8 +227,19 @@ enum UI_CTRL_IS_REDOABLE = 2;
 /* Some methods may use extra data */
 auto UI_set_app_data()(UI* s,void* arg) { return UI_set_ex_data(s,0,arg); }
 auto UI_get_app_data()(UI* s) { return UI_get_ex_data(s,0); }
-int UI_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
-	CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
+{
+	int UI_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto UI_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI, l, p, newf, dupf, freef);
+	}
+}
 int UI_set_ex_data(UI* r,int idx,void* arg);
 void* UI_get_ex_data(UI* r, int idx);
 

--- a/source/deimos/openssl/x509.d
+++ b/source/deimos/openssl/x509.d
@@ -865,9 +865,18 @@ X509_CERT_AUX* d2i_X509_CERT_AUX(X509_CERT_AUX** a, const(ubyte*)* in_, c_long l
 int i2d_X509_CERT_AUX(X509_CERT_AUX* a, ubyte** out_);
 extern __gshared const ASN1_ITEM X509_CERT_AUX_it;
 
-extern (D) auto X509_get_ex_new_index(T0, T1, T2, T3, T4)(auto ref T0 l, auto ref T1 p, auto ref T2 newf, auto ref T3 dupf, auto ref T4 freef)
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
 {
-    return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509, l, p, newf, dupf, freef);
+	int X509_get_ex_new_index(c_long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	extern (D) auto X509_get_ex_new_index () (c_long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509, l, p, newf, dupf, freef);
+	}
 }
 
 int X509_set_ex_data(X509* r, int idx, void* arg);

--- a/source/deimos/openssl/x509_vfy.d
+++ b/source/deimos/openssl/x509_vfy.d
@@ -419,10 +419,20 @@ X509_STORE_CTX_lookup_crls_fn X509_STORE_get_lookup_crls(X509_STORE* ctx);
 void X509_STORE_set_cleanup(X509_STORE* ctx, X509_STORE_CTX_cleanup_fn cleanup);
 X509_STORE_CTX_cleanup_fn X509_STORE_get_cleanup(X509_STORE* ctx);
 
-extern (D) auto X509_STORE_get_ex_new_index(T0, T1, T2, T3, T4)(auto ref T0 l, auto ref T1 p, auto ref T2 newf, auto ref T3 dupf, auto ref T4 freef)
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
 {
-    return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE, l, p, newf, dupf, freef);
+	int X509_STORE_get_ex_new_index(long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
 }
+else
+{
+	auto X509_STORE_get_ex_new_index () (long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE, l, p, newf, dupf, freef);
+	}
+}
+
 
 int X509_STORE_set_ex_data(X509_STORE* ctx, int idx, void* data);
 void* X509_STORE_get_ex_data(X509_STORE* ctx, int idx);
@@ -529,9 +539,18 @@ int X509_STORE_load_locations(
     const(char)* dir);
 int X509_STORE_set_default_paths(X509_STORE* ctx);
 
-extern (D) auto X509_STORE_CTX_get_ex_new_index(T0, T1, T2, T3, T4)(auto ref T0 l, auto ref T1 p, auto ref T2 newf, auto ref T3 dupf, auto ref T4 freef)
+static if (OPENSSL_VERSION_BEFORE(1, 1, 0))
 {
-    return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE_CTX, l, p, newf, dupf, freef);
+	int X509_STORE_CTX_get_ex_new_index(long argl, void* argp, CRYPTO_EX_new* new_func,
+		CRYPTO_EX_dup* dup_func, CRYPTO_EX_free* free_func);
+}
+else
+{
+	auto X509_STORE_CTX_get_ex_new_index () (long l, void* p, CRYPTO_EX_new* newf,
+		CRYPTO_EX_dup* dupf, CRYPTO_EX_free* freef)
+	{
+		return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE_CTX, l, p, newf, dupf, freef);
+	}
 }
 
 int X509_STORE_CTX_set_ex_data(X509_STORE_CTX* ctx, int idx, void* data);
@@ -681,4 +700,3 @@ stack_st_POLICYQUALINFO* X509_policy_node_get0_qualifiers(
     const(X509_POLICY_NODE)* node);
 const(X509_POLICY_NODE)* X509_policy_node_get0_parent(
     const(X509_POLICY_NODE)* node);
-


### PR DESCRIPTION
```
This change happened in v1.1.0 but was not applied to the bindings.
Some macros were introduced post-1.1 and the backward-compatible
definition has been introduced.
```

https://github.com/openssl/openssl/commit/e6390acac925f952cfd06ccdbba0b273b8f71551

Note that the above commit had bugs (see the `SSL_*` functions have their indexes swapped, `SESSION` uses `CTX`, `CTX uses `SSL`, and `SSL` uses `SESSION`...) but that was corrected later it seems.