### PR TITLE
dub: Switch to `library` target type

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,21 +5,21 @@ license "OpenSSL or SSLeay"
 libs "ssl" "crypto" platform="posix"
 
 configuration "library-autodetect" {
-	targetType "sourceLibrary"
+	targetType "library"
 	excludedSourceFiles "source/deimos/openssl/applink.d"
 	preGenerateCommands `${DUB} scripts/generate_version.d` platform="posix"
 	versions `DeimosOpenSSLAutoDetect`
 }
 
 configuration "library-manual-version" {
-	targetType "sourceLibrary"
+	targetType "library"
 	excludedSourceFiles "source/deimos/openssl/applink.d"
 }
 
 // Includes a module to replace `applink.c` as described in:
 // https://www.openssl.org/docs/manmaster/man3/OPENSSL_Applink.html
 configuration "library-applink" {
-	targetType "sourceLibrary"
+	targetType "library"
 }
 
 configuration "unittest" {


### PR DESCRIPTION
To prevent compiling these modules potentially multiple times (and with different flags) for a single binary, e.g., a binary transitively depending on N dub packages (static libs) with an `openssl` dependency, and the linker picking one of the N duplicate object files from the static libs.

Most notably, such duplicate builds don't work for some reggae modes, e.g., breaking per-package builds with `--dub-deps-objs`.