### PR TITLE
Avoid running dub recursively in pre-generate command, call D compiler directly

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,7 +7,7 @@ libs "ssl" "crypto" platform="posix"
 configuration "library-autodetect" {
 	targetType "sourceLibrary"
 	excludedSourceFiles "source/deimos/openssl/applink.d"
-	preGenerateCommands `${DUB} scripts/generate_version.d` platform="posix"
+	preGenerateCommands `$DC -run scripts/generate_version.d` platform="posix"
 	versions `DeimosOpenSSLAutoDetect`
 }
 

--- a/scripts/generate_version.d
+++ b/scripts/generate_version.d
@@ -30,7 +30,7 @@ import std.string;
 import std.uni;
 
 // file full path is: $SOME_PATH/openssl/scripts/generate_version.d
-// We want: $SOME_PATH/openssl/deimos/openssl/
+// We want: $SOME_PATH/openssl/source/deimos/openssl/
 immutable TARGET_DIR_PATH = __FILE_FULL_PATH__
     .dirName.dirName.buildPath("source", "deimos", "openssl");
 


### PR DESCRIPTION
As we see spurious failures (`version_.di` not generated/importable) when calling dub recursively.

The `generate_version` executable is built each time this way, not cached by dub anymore, but it's built pretty quickly (0.5 secs with LDC on my Linux x64 box, 0.3 secs with DMD).