### PR TITLE
Add some missing ECDSA_SIG_* functions

### DIFF
--- a/source/deimos/openssl/ecdsa.di
+++ b/source/deimos/openssl/ecdsa.di
@@ -91,6 +91,30 @@ ECDSA_SIG* ECDSA_SIG_new();
  */
 void	  ECDSA_SIG_free(ECDSA_SIG* sig);
 
+/** Accessor for r and s fields of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG structure
+ *  \param  pr   pointer to BIGNUM pointer for r (may be NULL)
+ *  \param  ps   pointer to BIGNUM pointer for s (may be NULL)
+ */
+void ECDSA_SIG_get0(const ECDSA_SIG *sig, const(BIGNUM*)* pr, const(BIGNUM*)* ps);
+
+/** Accessor for r field of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG structure
+ */
+const(BIGNUM)* ECDSA_SIG_get0_r(const(ECDSA_SIG)* sig);
+
+/** Accessor for s field of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG structure
+ */
+const(BIGNUM)* ECDSA_SIG_get0_s(const(ECDSA_SIG)* sig);
+
+/** Setter for r and s fields of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG structure
+ *  \param  r    pointer to BIGNUM for r
+ *  \param  s    pointer to BIGNUM for s
+ */
+int ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s);
+
 /** DER encode content of ECDSA_SIG object (note: this function modifies* pp
  * (*pp += length of the DER encoded signature)).
  * \param  sig  pointer to the ECDSA_SIG object


### PR DESCRIPTION
These functions are used in the `hunt-jwt` library. They are already in the outdated `hunt-openssl` fork of this package, but they should be useful over here as well.