### PR TITLE
Add EVP_PKEY_get_* and aliases for openssl>=3.0

### DIFF
--- a/source/deimos/openssl/evp.di
+++ b/source/deimos/openssl/evp.di
@@ -965,8 +965,16 @@ int		EVP_PKEY_encrypt_old(ubyte* enc_key,
 			const(ubyte)* key,int key_len,
 			EVP_PKEY* pub_key);
 int		EVP_PKEY_type(int type);
-int		EVP_PKEY_id(const(EVP_PKEY)* pkey);
-int		EVP_PKEY_base_id(const(EVP_PKEY)* pkey);
+static if (OPENSSL_VERSION_BEFORE(3, 0, 0)) {
+	int		EVP_PKEY_id(const(EVP_PKEY)* pkey);
+	int		EVP_PKEY_base_id(const(EVP_PKEY)* pkey);
+} else {
+	int		EVP_PKEY_get_id(const(EVP_PKEY)* pkey);
+	alias 	EVP_PKEY_id = EVP_PKEY_get_id;
+	
+	int		EVP_PKEY_get_base_id(const(EVP_PKEY)* pkey);
+	alias 	EVP_PKEY_base_id = EVP_PKEY_get_base_id;
+}
 int		EVP_PKEY_bits(EVP_PKEY* pkey);
 int		EVP_PKEY_size(EVP_PKEY* pkey);
 int 		EVP_PKEY_set_type(EVP_PKEY* pkey,int type);


### PR DESCRIPTION
`EVP_PKEY_id` and `EVP_PKEY_base_id` were renamed to `EVPK_PKEY_get_id` and `EVP_PKEY_get_base_id` respectively. Compatibility macros were added in openssl, but the linker is unaware of them, causing linker errors in some projects when linking them to openssl3.

https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_id.html#HISTORY