### PR TITLE
Changed in 3.0.0: EVP_PKEY_bits() and EVP_PKEY_size()

### DIFF
--- a/source/deimos/openssl/evp.di
+++ b/source/deimos/openssl/evp.di
@@ -987,15 +987,18 @@ int		EVP_PKEY_type(int type);
 static if (OPENSSL_VERSION_BEFORE(3, 0, 0)) {
 	int		EVP_PKEY_id(const(EVP_PKEY)* pkey);
 	int		EVP_PKEY_base_id(const(EVP_PKEY)* pkey);
+	int		EVP_PKEY_bits(EVP_PKEY* pkey);
+	int		EVP_PKEY_size(EVP_PKEY* pkey);
 } else {
 	int		EVP_PKEY_get_id(const(EVP_PKEY)* pkey);
 	alias 	EVP_PKEY_id = EVP_PKEY_get_id;
-	
 	int		EVP_PKEY_get_base_id(const(EVP_PKEY)* pkey);
 	alias 	EVP_PKEY_base_id = EVP_PKEY_get_base_id;
+	int		EVP_PKEY_get_bits(EVP_PKEY* pkey);
+	alias 	EVP_PKEY_bits = EVP_PKEY_get_bits;
+	int		EVP_PKEY_get_size(EVP_PKEY* pkey);
+	alias 	EVP_PKEY_size = EVP_PKEY_get_size;
 }
-int		EVP_PKEY_bits(EVP_PKEY* pkey);
-int		EVP_PKEY_size(EVP_PKEY* pkey);
 int 		EVP_PKEY_set_type(EVP_PKEY* pkey,int type);
 int		EVP_PKEY_set_type_str(EVP_PKEY* pkey, const(char)* str, int len);
 int 		EVP_PKEY_assign(EVP_PKEY* pkey,int type,void* key);


### PR DESCRIPTION
- The functions are renamed to EVP_PKEY_get_bits() and EVP_PKEY_get_size()
- Added new declarations for new names
- Added aliases for old names