### PR TITLE
Add a manual-linking configuration

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -2,17 +2,20 @@ name "openssl"
 description "Deimos bindings for the OpenSSL cryptographic library"
 homepage "http://www.openssl.org/"
 license "OpenSSL or SSLeay"
-libs "ssl" "crypto" platform="posix"
 
 configuration "library-autodetect" {
 	targetType "sourceLibrary"
+	libs "ssl" "crypto" platform="posix"
 	excludedSourceFiles "source/deimos/openssl/applink.d"
 	preGenerateCommands `$DC -run scripts/generate_version.d` platform="posix"
 	versions `DeimosOpenSSLAutoDetect`
 }
 
+// Requires a `versions "DeimosOpenSSL_3_0"` or `versions "DeimosOpenSSL_1_#_#"`
+// directive in a dependent package to select the right OpenSSL version
 configuration "library-manual-version" {
 	targetType "sourceLibrary"
+	libs "ssl" "crypto" platform="posix"
 	excludedSourceFiles "source/deimos/openssl/applink.d"
 }
 
@@ -20,4 +23,12 @@ configuration "library-manual-version" {
 // https://www.openssl.org/docs/manmaster/man3/OPENSSL_Applink.html
 configuration "library-applink" {
 	targetType "sourceLibrary"
+	libs "ssl" "crypto" platform="posix"
+}
+
+// See the "library-manual-version" configuration for how to
+// select the OpenSSL version
+configuration "library-manual-link" {
+	targetType "sourceLibrary"
+	excludedSourceFiles "source/deimos/openssl/applink.d"
 }


### PR DESCRIPTION
Allows an upstream package to provide the binaries required for linking. This is especially important for mobile platforms and in certain cross-compilation scenarios.