### PR TITLE
Support GDC by splitting run in build, execute and cleanup

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,7 +7,10 @@ configuration "library-autodetect" {
 	targetType "sourceLibrary"
 	libs "ssl" "crypto" platform="posix"
 	excludedSourceFiles "source/deimos/openssl/applink.d"
-	preGenerateCommands `$DC -run scripts/generate_version.d` platform="posix"
+	preGenerateCommands `$DC -run scripts/generate_version.d` platform="posix-ldc"
+	preGenerateCommands `$DC -run scripts/generate_version.d` platform="posix-dmd"
+	preGenerateCommands `$DC scripts/generate_version.d -o generate_version` `./generate_version` platform="posix-gdc"
+	postGenerateCommands `rm generate_version` platform="posix-gdc"
 	versions `DeimosOpenSSLAutoDetect`
 }
 


### PR DESCRIPTION
Hello, i tried to use gdc for a project and this library fail to compile because gdc doesn't support -run, so i thought i could "emulate" the run behaviour by compiling/running/deleting the script for target posix-gdc.

Disclaimer:
I tried this modification only to build my own project in fedora 40, so review this and please provide feedback if i need to change something.